### PR TITLE
Fix cohort creation

### DIFF
--- a/app/models/census_cohort.rb
+++ b/app/models/census_cohort.rb
@@ -6,7 +6,7 @@ class CensusCohort
 
   def self.create_cohorts(cohorts)
     cohorts.map do |cohort|
-      TuringCohort.where(id: cohort[:id])
+      TuringCohort.where(census_id: cohort["id"])
         .first_or_create do |c|
           c.census_id = cohort["id"]
           c.name      = cohort["name"]


### PR DESCRIPTION
Closes #25 

* Updates CensusCohort to check the `census_id` in our database against the `id` coming from Census.