### PR TITLE
Add markdown parsing to rubrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'figaro'
 gem 'faraday'
 gem 'active_designer'
 gem 'jquery-rails'
+gem 'redcarpet'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redcarpet (3.4.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -248,6 +249,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.0)
+  redcarpet
   rspec-rails
   sass-rails (~> 5.0)
   tzinfo-data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,16 @@
 module ApplicationHelper
+  def markdown(text)
+    renderer = Redcarpet::Render::HTML.new(excape_html: true)
+
+    markdown = Redcarpet::Markdown.new(renderer,
+                                       no_intra_emphasis: true,
+                                       fenced_code_blocks: true,
+                                       disable_indented_code_blocks: true,
+                                       autolink: true,
+                                       tables: true,
+                                       underline: true,
+                                       highlight: true
+                                      )
+    return markdown.render(text).html_safe if text
+  end
 end

--- a/app/views/instructors/projects/_rubric_table.html.erb
+++ b/app/views/instructors/projects/_rubric_table.html.erb
@@ -9,7 +9,7 @@
   <% @project.rubrics.each do |rubric| %>
     <tr>
       <td><%= rubric.rubric_category.title %></td>
-      <td><%= rubric.description %></td>
+      <td><%= markdown(rubric.description) %></td>
       <td><%= link_to "Edit", edit_instructors_rubric_path(rubric) %></td>
       <td><%= link_to "Delete", instructors_rubric_path(rubric), method: "DELETE" %></td>
     </tr>

--- a/app/views/instructors/projects/show.html.erb
+++ b/app/views/instructors/projects/show.html.erb
@@ -13,8 +13,8 @@
 <%= form_for [:instructors, @project, @rubric] do |f| %>
   <%= f.label :rubric_category %><br>
   <%= f.collection_select(:rubric_category_id, RubricCategory.all, :id, :title) %><br>
-  <%= f.label :description %><br>
-  <%= f.text_area :description %><br>
+  <%= f.label :description, "Description (markdown permitted)" %><br>
+  <%= f.text_area :description, rows: 15 %><br>
   <%= f.submit "Add Rubric Category" %>
 <% end %>
 


### PR DESCRIPTION
Allows instructors to use markdown when creating a new rubric.

Closes #41.