### PR TITLE
Add ability for instructor to un-assign a project/student

### DIFF
--- a/app/assets/stylesheets/base.scss.erb
+++ b/app/assets/stylesheets/base.scss.erb
@@ -141,3 +141,23 @@ form {
     width: 100%
   }
 }
+
+.ungraded-student {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 40px;
+  width: 30%;
+  justify-content: space-between;
+}
+
+.delete-btn {
+  background-color: #f84544;
+  border-radius: 3px;
+  border: none;
+  font-size: 80%;
+  padding: 5px;
+  color: #fff;
+  width: 40%;
+  cursor: pointer;
+}

--- a/app/controllers/instructors/assignments_controller.rb
+++ b/app/controllers/instructors/assignments_controller.rb
@@ -10,6 +10,11 @@ class Instructors::AssignmentsController < Instructors::BaseController
     redirect_to instructors_student_path(@student.id)
   end
 
+  def destroy
+    assignment = Assignment.destroy(params[:id])
+    redirect_to instructors_project_path(assignment.project_id)
+  end
+
   private
   def assignment_params
     params.require(:assignment).permit(:project_id)

--- a/app/views/instructors/projects/show.html.erb
+++ b/app/views/instructors/projects/show.html.erb
@@ -22,7 +22,9 @@
 
 <ul>
   <% @project.ungraded_assignments.each do |assignment| %>
-    <li><%= link_to assignment.census_user.full_name, new_instructors_assignment_score_path(assignment) %></li>
+    <li class="ungraded-student">
+      <%= link_to assignment.census_user.full_name, new_instructors_assignment_score_path(assignment) %>
+      <%= button_to("unassign", [:instructors, assignment], method: :delete, class: "delete-btn") %>
+    </li>
   <% end %>
 </ul>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     end
     resources :users, only: [:update]
 
-    resources :assignments, only: [] do
+    resources :assignments, only: [:destroy] do
       resources :scores, only: [:new, :create]
     end
     resources :turing_cohorts, only: [:index, :show, :create] do

--- a/spec/features/instructor/assignment_spec.rb
+++ b/spec/features/instructor/assignment_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe "As an instructor" do
+  describe "when I visit an assignment show page" do
+    it "I can delete an assignment for a student" do
+      census_cohort = CensusCohort.create_from_name("1409-BE")
+      project = Project.create(name: "Credit Check")
+      student = User.create(role: 'student', id: 75)
+      student.assignments.create(project: project)
+      instructor = User.create(role: 'instructor', flock_id: census_cohort.id)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(instructor)
+
+      visit instructors_project_path(project)
+
+      expect(page).to have_content("Molly Brown")
+
+      click_on "unassign"
+
+      expect(current_path).to eq(instructors_project_path(project))
+      expect(page).to_not have_content("Molly Brown")
+    end
+  end
+
+end


### PR DESCRIPTION
Closes #54 

On instructors_project view, where all students are listed (with link), they now each have an "unassign" button by their name. This allows instructors to unassign an individual from a given project.